### PR TITLE
fix uninitialized variable cmp

### DIFF
--- a/src/bin/state.c
+++ b/src/bin/state.c
@@ -67,8 +67,8 @@ static int neo4j_string_cmp(neo4j_value_t s1, neo4j_value_t s2)
 int shell_state_add_export(shell_state_t *state, neo4j_value_t name,
         neo4j_value_t value, void *storage)
 {
-    int cmp;
     unsigned int i;
+    int cmp = -1;
     for (i = 0; i < state->nexports &&
             (cmp = neo4j_string_cmp(state->exports[i].key, name)) < 0; ++i)
         ;


### PR DESCRIPTION
An error occurs in my env.

state.c' || echo './'`state.c
state.c: In function ‘shell_state_add_export’:
state.c:75:8: error: ‘cmp’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     if (cmp == 0)
        ^
cc1: all warnings being treated as errors
