### PR TITLE
"cast increases required alignment" warning

### DIFF
--- a/src/lib/result_stream.c
+++ b/src/lib/result_stream.c
@@ -580,7 +580,8 @@ int run_rs_close(neo4j_result_stream_t *self)
 neo4j_value_t run_result_field(const neo4j_result_t *self,
         unsigned int index)
 {
-    const result_record_t *record = (const result_record_t *)self;
+    const result_record_t *record = container_of(self,
+            result_record_t, _result);
     REQUIRE(record != NULL, neo4j_null);
     return neo4j_list_get(record->list, index);
 }


### PR DESCRIPTION
Hi,

This package failed to build for multiple architectures (mips*, armel, armhf, hppa, powerpcspe) with the following error:
result_stream.c: In function 'run_result_field':
result_stream.c:583:37: error: cast increases required alignment of target type [-Werror=cast-align]
     const result_record_t *record = (const result_record_t *)self;
                                     ^
Bug with proposed solution is reported on Debian: https://bugs.debian.org/833900

Thanks,
Daniel