### PR TITLE
Added missing functions and corrected documentation

### DIFF
--- a/lib/src/client_config.c
+++ b/lib/src/client_config.c
@@ -394,6 +394,13 @@ int neo4j_config_set_sndbuf_size(neo4j_config_t *config, size_t size)
 }
 
 
+size_t neo4j_config_get_sndbuf_size(const neo4j_config_t *config)
+{
+    REQUIRE(config != NULL, 0);
+    return config->io_sndbuf_size;
+}
+
+
 int neo4j_config_set_rcvbuf_size(neo4j_config_t *config, size_t size)
 {
     REQUIRE(config != NULL, -1);
@@ -401,6 +408,12 @@ int neo4j_config_set_rcvbuf_size(neo4j_config_t *config, size_t size)
     return 0;
 }
 
+
+size_t neo4j_config_get_rcvbuf_size(const neo4j_config_t *config)
+{
+    REQUIRE(config != NULL, 0);
+    return config->io_rcvbuf_size;
+}
 
 void neo4j_config_set_logger_provider(neo4j_config_t *config,
         struct neo4j_logger_provider *logger_provider)

--- a/lib/src/neo4j-client.h.in
+++ b/lib/src/neo4j-client.h.in
@@ -1220,9 +1220,8 @@ int neo4j_config_set_basic_auth_callback(neo4j_config_t *config,
  *
  * @param [config] The neo4j client configuration to update.
  * @param [path] The path to the PEM file containing the private key
- *         and certificate chain. This string should remain allocated whilst
- *         the config is allocated _or if any connections opened with the
- *         config remain active_.
+ *         and certificate chain. The string will be
+ *         duplicated, and thus may point to temporary memory.
  * @return 0 on success, or -1 on error (errno will be set).
  */
 __neo4j_must_check
@@ -1274,8 +1273,7 @@ int neo4j_config_set_TLS_private_key_password(neo4j_config_t *config,
  *
  * @param [config] The neo4j client configuration to update.
  * @param [path] The path to the PEM file containing the trusted CAs and CRLs.
- *         This string should remain allocated whilst the config is allocated
- *         _or if any connections opened with the config remain active_.
+ *         The string will be duplicated, and thus may point to temporary memory.
  * @return 0 on success, or -1 on error (errno will be set).
  */
 __neo4j_must_check
@@ -1296,9 +1294,8 @@ const char *neo4j_config_get_TLS_ca_file(const neo4j_config_t *config);
  * and CRLs, named by hash according to the `c_rehash` tool.
  *
  * @param [config] The neo4j client configuration to update.
- * @param [path] The path to the directory of CAs and CRLs. This string should
- *         remain allocated whilst the config is allocated _or if any
- *         connections opened with the config remain active_.
+ * @param [path] The path to the directory of CAs and CRLs.  The string will be
+ *         duplicated, and thus may point to temporary memory.
  * @return 0 on success, or -1 on error (errno will be set).
  */
 __neo4j_must_check
@@ -1346,9 +1343,8 @@ bool neo4j_config_get_trust_known_hosts(const neo4j_config_t *config);
  * will be used for storing trust information when using "Trust On First Use".
  *
  * @param [config] The neo4j client configuration to update.
- * @param [path] The path to known hosts file. This string should
- *         remain allocated whilst the config is allocated _or if any
- *         connections opened with the config remain active_.
+ * @param [path] The path to known hosts file. The string will be
+ *         duplicated, and thus may point to temporary memory.
  * @return 0 on success, or -1 on error (errno will be set).
  */
 __neo4j_must_check


### PR DESCRIPTION
While developing a header only c++ wrapper around this library I stumbled upon some minor problems:
* The functions `neo4j_config_get_rcvbuf_size` and `neo4j_config_get_sndbuf_size` are declared in the library header file, but not implemented, causing undefined reference errors if you try to use them.
* The documentation for `neo4j_config_set_TLS_private_key`, `neo4j_config_set_TLS_ca_file`, `neo4j_config_set_TLS_ca_dir` and `neo4j_config_set_known_hosts_file` was wrong. The arguments are in fact copied and there is no need to keep them allocated after they return.